### PR TITLE
* v1.12.0 --> v1.12.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2022-01-24
+### Changed
+- readme feature section updated for search and auth
+- tmdbId returned from custom GraphQL queries
+
+### Fixed
+- show creation unrecognized fields
+- source 'UR' for getShows request to omit WL items
+- showIdx determination for all views
+
 ## [1.12.0] - 2022-01-23
 ### Added
 - Show's source field added to algolia

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Features
 
-+ Federated, live, search for rated and unrated shows with autosuggest, fuzzy matching, and result grouping
++ Federated, live, search for rated/unrated shows with fuzzy matching and result grouping
   + Rated shows retrieved from [Algolia](https://www.algolia.com/products/search-and-discovery/hosted-search-api/)
   + Unrated shows retrieved from [TMDB API](https://developers.themoviedb.org/3/)
 + Client and server side caching of search results
@@ -41,6 +41,7 @@
   + Fetches paginated shows from GraphQL when user scrolls to end of page
 + AWS Cognito user auth
   + signup, login, and logout
+  + GraphQL read/write auth
 + Views for trending shows, recently rated, recently released, tv, movies, watchlist, watched, and favorites.
 + User profile with customizable avatar and display name
 + Posts to a Discord webhook when a show is first rated

--- a/components/MainView.jsx
+++ b/components/MainView.jsx
@@ -610,7 +610,9 @@ const MainView = ({ authedUser }) => {
     if (rating && show.rating === 0) { // unrated WL item
       API.graphql(graphqlOperation(updateShow, { input: { ...ratedShow, id: show.id } }));
     } else { // unrated show
-      API.graphql(graphqlOperation(createShow, { input: { ...show, ...ratedShow } }))
+      const { reviews, updatedAt, ...input } = { ...show, ...ratedShow };
+
+      API.graphql(graphqlOperation(createShow, { input }))
         .catch((err) => {
           console.error('GraphQL create show failed. ', err);
         });
@@ -804,7 +806,7 @@ const MainView = ({ authedUser }) => {
         <Grid container spacing={3} wrap="wrap">
           {
             shows.slice(view === View.HOME ? trendingShows.length : 0)
-              .map((show, i) => renderShowCard(show, View.HOME ? trendingShows.length + i : 0))
+              .map((show, i) => renderShowCard(show, view === View.HOME ? trendingShows.length + i : i))
           }
         </Grid>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-ratings",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A site for rating TV shows and movies",
   "repository": {
     "type": "git",

--- a/src/graphql/custom-queries.js
+++ b/src/graphql/custom-queries.js
@@ -17,6 +17,7 @@ export const recentlyRated = /* GraphQL */ `
     ) {
       items {
         id
+        tmdbId
         title
         type
         rating
@@ -67,6 +68,7 @@ export const showsByType = /* GraphQL */ `
     ) {
       items {
         id
+        tmdbId
         title
         type
         rating
@@ -102,6 +104,7 @@ export const getShow = /* GraphQL */ `
   query GetShow($id: ID!) {
     getShow(id: $id) {
       id
+      tmdbId
       title
       type
       rating
@@ -150,6 +153,7 @@ export const reviewsByUser = /* GraphQL */ `
       items {
         show {
           id
+          tmdbId
           title
           type
           rating
@@ -189,6 +193,7 @@ export const getUser = /* GraphQL */ `
         items {
           show {
             id
+            tmdbId
             title
             type
             rating

--- a/src/model/View.js
+++ b/src/model/View.js
@@ -1,12 +1,13 @@
-const recentlyRatedArgs = ['recentlyRated', { source: 'UR' }];
+const source = 'UR';
+const recentlyRatedArgs = ['recentlyRated', { source }];
 const newReleaseThreshold = new Date();
 
 newReleaseThreshold.setMonth(newReleaseThreshold.getMonth() - 3);
 
 export default class View {
   static HOME = new View('Home', ...recentlyRatedArgs);
-  static TV = new View('TV Shows', 'showsByType', { type: 'tv' });
-  static MOVIES = new View('Movies', 'showsByType', { type: 'movie' });
+  static TV = new View('TV Shows', 'showsByType', { type: 'tv', source });
+  static MOVIES = new View('Movies', 'showsByType', { type: 'movie', source });
   static FAVORITES = new View('Favorites', 'reviewsByUser', { filter: { isFavorite: { eq: true } } });
   static WATCHLIST = new View('Watchlist');
   static WATCHED = new View('Watched', 'reviewsByUser');


### PR DESCRIPTION
* all views now specify source 'UR' for getShows request to omit WL items.
* tmdbId returned from custom GraphQL queries.
* show creation no longer sending reviews and updatedAt fields.
* showIdx for non-HOME views properly set.
* readme feature section updated for search and auth.