### PR TITLE
- graphql getUser query watchlist items limit increased (100 --> 1000).

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+amplify-codegen-temp\models\models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - 2023-##-##
 
+## [1.21.2] - 2024-01-28
+### Changed
+- graphql getUser query watchlist items limit increased (100 --> 1000).
+
+### Fixed
+- deprecated default import of aws-amplify replaced with named import.
+
 ## [1.21.1] - 2023-10-17
 ### Fixed
 - dense schedule view card width reduced for small mobile devices

--- a/amplify/backend/api/universalratings/schema.graphql
+++ b/amplify/backend/api/universalratings/schema.graphql
@@ -25,7 +25,7 @@ type User @model
   color: String!
   themePref: String
   plexSearchEnabled: Boolean
-  watchlist: [WatchlistItem] @connection(fields: ["id"])
+  watchlist: [WatchlistItem] @connection(fields: ["id"], limit: 1000)
 }
 
 type Review @model

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,47 +1,47 @@
 export type AmplifyDependentResourcesAttributes = {
-    "auth": {
-        "universalratings5a980c73": {
-            "IdentityPoolId": "string",
-            "IdentityPoolName": "string",
-            "UserPoolId": "string",
-            "UserPoolArn": "string",
-            "UserPoolName": "string",
-            "AppClientIDWeb": "string",
-            "AppClientID": "string",
-            "CreatedSNSRole": "string"
-        },
-        "userPoolGroups": {
-            "AdminGroupRole": "string"
-        }
-    },
-    "api": {
-        "universalratings": {
-            "GraphQLAPIIdOutput": "string",
-            "GraphQLAPIEndpointOutput": "string"
-        }
-    },
-    "function": {
-        "universalratings5a980c73PostConfirmation": {
-            "Name": "string",
-            "Arn": "string",
-            "LambdaExecutionRole": "string",
-            "Region": "string",
-            "LambdaExecutionRoleArn": "string"
-        },
-        "ShowAddedDiscordWebhookPublisher": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string",
-            "LambdaExecutionRoleArn": "string"
-        },
-        "UpdateShowsMetadata": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string",
-            "CloudWatchEventRule": "string",
-            "LambdaExecutionRoleArn": "string"
-        }
+  "api": {
+    "universalratings": {
+      "GraphQLAPIEndpointOutput": "string",
+      "GraphQLAPIIdOutput": "string"
     }
+  },
+  "auth": {
+    "universalratings5a980c73": {
+      "AppClientID": "string",
+      "AppClientIDWeb": "string",
+      "CreatedSNSRole": "string",
+      "IdentityPoolId": "string",
+      "IdentityPoolName": "string",
+      "UserPoolArn": "string",
+      "UserPoolId": "string",
+      "UserPoolName": "string"
+    },
+    "userPoolGroups": {
+      "AdminGroupRole": "string"
+    }
+  },
+  "function": {
+    "ShowAddedDiscordWebhookPublisher": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "UpdateShowsMetadata": {
+      "Arn": "string",
+      "CloudWatchEventRule": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "universalratings5a980c73PostConfirmation": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    }
+  }
 }

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -33,6 +33,9 @@
           "deploymentBucketName": "amplify-amplify6604b332b57b4-staging-21636-deployment",
           "s3Key": "amplify-builds/UpdateShowsMetadata-376e52585a7a2f353170-build.zip"
         }
+      },
+      "api": {
+        "universalratings": {}
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-ratings",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "A site for rating TV shows and movies",
   "repository": {
     "type": "git",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,7 +4,7 @@ import API, { graphqlOperation } from '@aws-amplify/api';
 import { getUser } from '../src/graphql/custom-queries.js';
 import { AmplifyAuthContainer, AmplifyAuthenticator } from '@aws-amplify/ui-react';
 import { AuthState } from '@aws-amplify/ui-components';
-import amplify from 'aws-amplify';
+import { Amplify as amplify } from 'aws-amplify';
 import amplifyConfig from '../src/aws-exports';
 import { ThemeProvider } from '../components/ThemeProvider.jsx';
 import '../resources/styles/global.css';


### PR DESCRIPTION
- deprecated default import of aws-amplify replaced with named import.